### PR TITLE
Use minutes instead of hours #16

### DIFF
--- a/Upload/newpoints.php
+++ b/Upload/newpoints.php
@@ -230,7 +230,7 @@ elseif ($mybb->input['action'] == 'do_donate')
 	
 	if($mybb->user['usergroup'] != 4)
 	{
-		$q = $db->simple_select('newpoints_log', 'COUNT(*) as donations', 'action=\'donation\' AND date>'.(TIME_NOW-15*60*60).' AND uid='.(int)$mybb->user['uid']);
+		$q = $db->simple_select('newpoints_log', 'COUNT(*) as donations', 'action=\'donation\' AND date>'.(TIME_NOW-15*60).' AND uid='.(int)$mybb->user['uid']);
 		$totaldonations = (int)$db->fetch_field($q, 'donations');
 		if($totaldonations >= MAX_DONATIONS_CONTROL)
 		{


### PR DESCRIPTION
**Description**
newpoints has a feature that limits amount of donations that the user can make in 15 minutes.
This implementation has a bug, instead of limiting the donation amount to 15 minutes, it limits it to 15 hours.

**Changes**
* Updated donation limit implementation to use minutes instead of hours.

**Issues**
* Fixes #16 